### PR TITLE
Switch to setuptools.  Now can install with running develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup, Extension
 import numpy
 import sys
 import os


### PR DESCRIPTION
Was getting an import error when running nosetests.  Found help from a similar problem on [SO](http://stackoverflow.com/questions/22214022/how-to-run-nosetests-in-a-project-using-cython).  You can now install with `python setup.py develop`, and then run nosetests.