### PR TITLE
Speed optimisations to orthonormal update

### DIFF
--- a/pyearth/test/test_basis.py
+++ b/pyearth/test/test_basis.py
@@ -119,7 +119,7 @@ class TestSmoothedHingeBasisFunction(BaseTestClass):
         c1[self.X[:, 1] >= 3.0] = self.X[self.X[:, 1] >= 3.0, 1] - 1.0
         c2 = numpy.ones(m)
         c2[self.X[:, 1] >= 3.0] = 0.0
-        c2[self.X[:, 1] <= 0.0] = -1 * (self.X[self.X[:, 1] <= 0.0] - 1.0)
+        c2.flat[self.X[:, 1] <= 0.0] = -1 * (self.X[self.X[:, 1] <= 0.0] - 1.0)
         c2[(self.X[:, 1] > 0.0) & (self.X[:, 1] < 3.0)] = (
             pminus*((self.X[(self.X[:, 1] > 0.0) &
                     (self.X[:, 1] < 3.0), 1] - 3.0)**2) +
@@ -145,7 +145,7 @@ class TestSmoothedHingeBasisFunction(BaseTestClass):
         c1[self.X[:, 1] >= 3.0] = self.X[self.X[:, 1] >= 3.0, 1] - 1.0
         c2 = numpy.ones(m)
         c2[self.X[:, 1] >= 3.0] = 0.0
-        c2[self.X[:, 1] <= 0.0] = -1 * (self.X[self.X[:, 1] <= 0.0] - 1.0)
+        c2.flat[self.X[:, 1] <= 0.0] = -1 * (self.X[self.X[:, 1] <= 0.0] - 1.0)
         c2[(self.X[:, 1] > 0.0) & (self.X[:, 1] < 3.0)] = (
             pminus*((self.X[(self.X[:, 1] > 0.0) &
                     (self.X[:, 1] < 3.0), 1] - 3.0)**2) +


### PR DESCRIPTION
The orthonormal update is a major bottleneck. It seems that using the default numpy.dot() function with vector slice inputs is faster than rolling our own with Cython. Also aligning the 'B' matrices as Fortran (column) major speed things up a bit. I was able to get a 30% speed improvement here. There may be a way to speed things further with a BLAS level 2 call, but I need to work this out first.

There was also a deprecation warning in the unit tests which was fixed.